### PR TITLE
fix CI tests

### DIFF
--- a/molecule/default/vars/apps.yml
+++ b/molecule/default/vars/apps.yml
@@ -1,18 +1,18 @@
 clusters:
-  another_cluster:
+  another_cluster: |
     v2:
-      metadata:
-        title: Another Cluster
-  my_cluster:
+        metadata:
+            title: Another Cluster
+  my_cluster: |
     v2:
-      metadata:
-        title: my_cluster
-      login:
-        host: my_host
-      job:
-        adapter: slurm
-        bin: /usr/local
-      batch_connect:
+        batch_connect: null
+        job:
+            adapter: slurm
+            bin: /usr/local
+        login:
+            host: my_host
+        metadata:
+            title: my_cluster
 
 ood_install_apps:
   jupyter:


### PR DESCRIPTION
align vars `my_cluster` and `another_cluster` in molecule/default/vars/apps.yml and molecule/default/fixtures/clusters.d/ so diff test dont crash

this is the failing test https://github.com/OSC/ood-ansible/blob/master/molecule/default/verify_custom.yml#L14-L24